### PR TITLE
Neovimにファイルの相対パス+行番号コピーコマンドを追加

### DIFF
--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -61,6 +61,13 @@ if vim.fn.isdirectory("src") == 1 or vim.fn.filereadable("package.json") == 1 th
   map("n", "<leader>df", "<cmd>!npm run lint -- --fix<cr>", { desc = "Fix linting errors" })
 end
 
+-- Copy relative path with line number (e.g. app/models/user.rb:42)
+map("n", "<leader>yp", function()
+  local path = vim.fn.expand("%:.") .. ":" .. vim.fn.line(".")
+  vim.fn.setreg("+", path)
+  vim.notify("Copied: " .. path)
+end, { desc = "Copy relative path with line number" })
+
 -- Better terminal navigation for Rails
 map("t", "<C-h>", "<C-\\><C-n><C-w>h", { desc = "Terminal left" })
 map("t", "<C-j>", "<C-\\><C-n><C-w>j", { desc = "Terminal down" })


### PR DESCRIPTION
## 概要
`<leader>yp` キーマップを追加し、現在のファイルの相対パスと行番号（例: `app/models/user.rb:42`）をクリップボードにコピーできるようにしました。

## 変更内容
- `nvim/lua/config/keymaps.lua` に `<leader>yp` キーマップを追加
  - 相対パス + 行番号（`:` 区切り）をクリップボード（`+` レジスタ）にコピー
  - コピー後に通知メッセージを表示

## テスト方法
1. Neovimでファイルを開く
2. `<leader>yp` を押す
3. クリップボードに `ファイルパス:行番号` の形式でコピーされることを確認