### PR TITLE
AeroSpace の設定改善と borders 追加

### DIFF
--- a/.config/aerospace/aerospace.toml
+++ b/.config/aerospace/aerospace.toml
@@ -77,6 +77,7 @@ alt-9 = 'workspace 9'
 
 # --- ワークスペース切り替え（アルファベット）---
 # alt-a → Arc起動に使用
+# alt-f → フルスクリーン切り替えに使用
 # alt-i → WezTerm起動に使用
 # alt-n → Notion起動に使用
 # alt-o → Obsidian起動に使用
@@ -95,8 +96,10 @@ alt-shift-9 = 'move-node-to-workspace 9'
 
 # --- ウィンドウをワークスペースに移動（アルファベット）---
 alt-shift-a = 'move-node-to-workspace A'
+alt-shift-f = 'move-node-to-workspace F'
 alt-shift-i = 'move-node-to-workspace I'
 alt-shift-n = 'move-node-to-workspace N'
+alt-shift-o = 'move-node-to-workspace O'
 alt-shift-s = 'move-node-to-workspace S'
 
 # --- モニター間移動 ---
@@ -145,4 +148,14 @@ run = 'move-node-to-workspace S'
 [[on-window-detected]]
 if.app-id = 'notion.id'
 run = 'move-node-to-workspace N'
+
+# Figma → ワークスペース F
+[[on-window-detected]]
+if.app-id = 'com.figma.Desktop'
+run = 'move-node-to-workspace F'
+
+# Obsidian → ワークスペース O
+[[on-window-detected]]
+if.app-id = 'md.obsidian'
+run = 'move-node-to-workspace O'
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ brew install --cask wezterm@nightly
 
 ```bash
 brew install --cask nikitabobko/tap/aerospace
+brew tap FelixKratz/formulae
+brew install borders  # アクティブウィンドウのボーダー表示
 ```
 
 ### ターミナルマルチプレクサ

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ brew install --cask wezterm@nightly
 ### ウィンドウマネージャー
 
 ```bash
-brew install --cask aerospace
+brew install --cask nikitabobko/tap/aerospace
 ```
 
 ### ターミナルマルチプレクサ
@@ -100,16 +100,16 @@ brew install zellij
 
 キーバインド：
 
-| キー | 動作 |
-|------|------|
-| `Alt + hjkl` | フォーカス移動 |
-| `Alt + Shift + hjkl` | ウィンドウ移動 |
-| `Alt + 1-9` | ワークスペース切り替え |
-| `Alt + S` | Slack ワークスペース |
-| `Alt + M` | Music ワークスペース |
-| `Alt + B` | Browser ワークスペース |
-| `Alt + F` | フルスクリーン |
-| `Alt + Shift + ;` | サービスモード（設定リロード等） |
+| キー                 | 動作                             |
+| -------------------- | -------------------------------- |
+| `Alt + hjkl`         | フォーカス移動                   |
+| `Alt + Shift + hjkl` | ウィンドウ移動                   |
+| `Alt + 1-9`          | ワークスペース切り替え           |
+| `Alt + S`            | Slack ワークスペース             |
+| `Alt + M`            | Music ワークスペース             |
+| `Alt + B`            | Browser ワークスペース           |
+| `Alt + F`            | フルスクリーン                   |
+| `Alt + Shift + ;`    | サービスモード（設定リロード等） |
 
 アプリのワークスペース自動割り当て：Chrome/Firefox/Safari → B、WezTerm → 1、Slack → S、Spotify → M
 


### PR DESCRIPTION
## 概要
AeroSpace の設定を改善し、Figma と Obsidian のワークスペース自動割り当てを追加しました。また、アクティブウィンドウを視覚的に確認できるよう borders のセットアップ手順も追加しています。

## 変更内容
- AeroSpace に Figma (ワークスペース F) と Obsidian (ワークスペース O) の自動割り当て設定を追加
- \`alt-shift-f\` と \`alt-shift-o\` のキーバインドを追加
- README.md に borders のインストール手順を追加
- README.md の AeroSpace インストール手順を修正（正しい tap を使用）

## テスト方法
- AeroSpace の設定をリロード（\`alt-shift-;\` → \`esc\`）して、Figma と Obsidian が正しいワークスペースに割り当てられることを確認
- borders がインストールされ、アクティブウィンドウにボーダーが表示されることを確認