### PR TITLE
aerospaceのキーバインド調整：alt-fをFigma起動に変更

### DIFF
--- a/.config/aerospace/aerospace.toml
+++ b/.config/aerospace/aerospace.toml
@@ -62,7 +62,7 @@ alt-minus       = 'resize smart -50'
 alt-shift-minus = 'resize smart +50'
 
 # --- フルスクリーン ---
-alt-f = 'fullscreen'
+alt-enter = 'fullscreen'
 
 # --- ワークスペース切り替え（数字）---
 alt-1 = 'workspace 1'
@@ -77,7 +77,7 @@ alt-9 = 'workspace 9'
 
 # --- ワークスペース切り替え（アルファベット）---
 # alt-a → Arc起動に使用
-# alt-f → フルスクリーン切り替えに使用
+# alt-f → Figma起動に使用
 # alt-i → WezTerm起動に使用
 # alt-n → Notion起動に使用
 # alt-o → Obsidian起動に使用
@@ -107,6 +107,7 @@ alt-shift-tab = 'move-workspace-to-monitor --wrap-around next'
 
 # --- アプリ起動 ---
 alt-a = 'exec-and-forget open -a Arc'
+alt-f = 'exec-and-forget open -a Figma'
 alt-i = 'exec-and-forget open -a WezTerm'
 alt-n = 'exec-and-forget open -a Notion'
 alt-o = 'exec-and-forget open -a Obsidian'


### PR DESCRIPTION
## 概要

フルスクリーンのキーバインドをalt-enterに移動し、alt-fをFigma起動に割り当てました。これにより、他のアプリ起動キー（alt-a, alt-i, alt-n, alt-o, alt-s）との一貫性が向上します。

## 変更内容

- フルスクリーンのキーバインドを `alt-f` から `alt-enter` に変更
- `alt-f` を Figma 起動に割り当て
- 関連するコメントを更新（alt-fの用途説明）

## テスト方法

- AeroSpaceを再起動
- `alt-enter` でフルスクリーン切り替えが動作することを確認
- `alt-f` でFigmaが起動することを確認