### PR TITLE
aerospace: ウィンドウリサイズとワークスペース数を更新

### DIFF
--- a/.config/aerospace/aerospace.toml
+++ b/.config/aerospace/aerospace.toml
@@ -58,8 +58,9 @@ alt-shift-k = 'move up'
 alt-shift-l = 'move right'
 
 # --- リサイズ ---
-alt-minus       = 'resize smart -50'
-alt-shift-minus = 'resize smart +50'
+alt-minus = 'resize smart -100'
+alt-equal = 'resize smart +100'
+alt-0     = 'balance-sizes' # ウィンドウサイズを均等にする
 
 # --- フルスクリーン ---
 alt-enter = 'fullscreen'
@@ -70,10 +71,6 @@ alt-2 = 'workspace 2'
 alt-3 = 'workspace 3'
 alt-4 = 'workspace 4'
 alt-5 = 'workspace 5'
-alt-6 = 'workspace 6'
-alt-7 = 'workspace 7'
-alt-8 = 'workspace 8'
-alt-9 = 'workspace 9'
 
 # --- ワークスペース切り替え（アルファベット）---
 # alt-a → Arc起動に使用
@@ -89,10 +86,6 @@ alt-shift-2 = 'move-node-to-workspace 2'
 alt-shift-3 = 'move-node-to-workspace 3'
 alt-shift-4 = 'move-node-to-workspace 4'
 alt-shift-5 = 'move-node-to-workspace 5'
-alt-shift-6 = 'move-node-to-workspace 6'
-alt-shift-7 = 'move-node-to-workspace 7'
-alt-shift-8 = 'move-node-to-workspace 8'
-alt-shift-9 = 'move-node-to-workspace 9'
 
 # --- ウィンドウをワークスペースに移動（アルファベット）---
 alt-shift-a = 'move-node-to-workspace A'


### PR DESCRIPTION
- リサイズショートカットを変更
  - alt-minus: -50 → -100
  - alt-shift-minus を廃止し alt-equal (+100) に変更
  - alt-0 で balance-sizes（均等化）を追加
- ワークスペースを9個から5個に削減
  - alt-6〜alt-9 のワークスペース切り替えを削除
  - alt-shift-6〜alt-shift-9 のウィンドウ移動を削除

https://claude.ai/code/session_012gQ1Z3mQuWCVciMsJekoAt