### PR TITLE
install.sh修正: .configスキップ処理追加・global gitignore移行・ドキュメント整備

### DIFF
--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -1,0 +1,1 @@
+**/.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.local
+home/.config/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,25 +13,96 @@
 
 ## 重要なファイル
 
-- `.zshrc`: Zsh設定（条件付きツール読み込み）
-- `nvim/lua/plugins/claudecode.lua`: Claude Code設定
-- `.claude/`: 詳細ドキュメント
+- `home/.zshrc`: Zsh設定（条件付きツール読み込み）
+- `.config/nvim/lua/plugins/claudecode.lua`: Claude Code設定
+- `install.sh`: シンボリックリンク一括作成スクリプト
+
+## install.sh の仕組み
+
+3フェーズでシンボリックリンクを作成する。何度実行しても安全（冪等）。
+
+**Phase 1: `~/.config/*`**
+`.config/` 以下のディレクトリを自動検出して `~/.config/<tool>` にリンク。
+新ツール追加時は `dotfiles/.config/<tool>/` を作成するだけでOK。
+
+**Phase 2: `~/.*`（home dotfiles）**
+`home/` 以下のドットファイルをホームディレクトリにリンク。
+`home/.config/` は `[[ "$base" == ".config" ]] && continue` で**明示的にスキップ**（Phase 1 で管理）。
+
+**Phase 3: Claude Code ファイル**
+`.claude/commands/*.md` と `.claude/agents/*.md` を**ファイル単位**でリンク。
+`~/.claude/` はランタイムデータを含むため、ディレクトリ丸ごとはリンクしない。
+
+**safe_link() の動作:**
+- 正しいリンクが既に存在 → 何もしない（`Already linked:`）
+- 既存ファイル/ディレクトリ/リンクがある → `~/.dotfiles_backup/<timestamp>/` にバックアップして置き換え
+- ソースが存在しない → スキップ（警告表示）
+
+## ⚠️ 重大インシデントの教訓（commit ba2c63a）
+
+**経緯**: Claude が `~/.config` 全体をシンボリックリンクしようとし、`~/.config/` 配下のツール別個別リンク群を丸ごと置き換えかけた。
+
+### 絶対にやってはいけない操作
+
+1. **`~/.config/` をディレクトリ丸ごとシンボリックリンクしない**
+   - `~/.config/` 配下には各ツールが自動生成したファイルが混在している
+   - 管理は常に `~/.config/<tool>/` 単位で行う
+
+2. **`~/.claude/` をディレクトリ丸ごとシンボリックリンクしない**
+   - Claude Code のメモリ・プロジェクトキャッシュ・ランタイムデータが含まれる
+   - 管理は常にファイル単位（`commands/*.md`, `agents/*.md`）で行う
+
+3. **`~/.config/` 配下で `rm -rf` や `mv` を使った破壊的操作をしない**
+   - 既存リンクや他ツールの設定を巻き込む危険がある
+
+### install.sh の防止策（現在のコード）
+
+```bash
+# home/ ループで .config を明示的にスキップ（install.sh:81）
+[[ "$base" == ".config" ]] && continue  # .config は別途 .config/*/ ループで管理
+
+# .config は個別ツールディレクトリ単位でリンク（install.sh:66-70）
+for src_dir in "$DOTFILES_DIR/.config"/*/; do
+    safe_link "$src_dir" "$HOME/.config/$tool_name"  # ~/.config 自体はリンクしない
+done
+
+# .claude はファイル単位でリンク（install.sh:93-99）
+for f in "$DOTFILES_DIR/.claude/commands"/*.md; do
+    safe_link "$f" "$HOME/.claude/commands/$(basename "$f")"
+done
+```
 
 ## 開発フロー
 
-1. 新しいツール追加時はHomebrewでインストール
-2. 設定ファイルを適切なディレクトリに配置
-3. README.mdにセットアップ手順を追加
-4. 必要に応じて`.claude/`配下にドキュメント作成
+### 新しいツールの設定を追加
+
+```bash
+mkdir .config/<tool>
+# 設定ファイルを配置
+./install.sh  # 自動検出してリンク作成
+```
+
+### 既存設定の変更
+
+dotfiles リポジトリ内のファイルを直接編集するだけでOK（シンボリックリンクなので即反映）。install.sh の再実行は不要。
+
+### install.sh の再実行
+
+何度実行しても安全。`Already linked:` が表示されれば正常。
 
 ## テストコマンド
 
 ```bash
+# install.sh の冪等動作確認（Already linked: が表示されればOK）
+./install.sh
+
+# シンボリックリンク確認
+ls -la ~/.config/ | grep '\->'
+ls -la ~ | grep '\->'
+ls -la ~/.claude/commands/ | grep '\->'
+
 # Zsh設定確認
 source ~/.zshrc
-
-# Neovim起動確認
-nvim
 
 # 各ツール動作確認
 mise --version
@@ -44,6 +115,5 @@ atuin --version
 ## 注意点
 
 - 各ツールは条件付きで読み込み（インストール済みの場合のみ）
-- シンボリックリンクでファイルを配置
-- ローカル固有設定は`~/.zshrc.local`で管理
-
+- ローカル固有設定は `~/.zshrc.local` で管理（git 管理外）
+- `home/.config/` は git 管理外（`gcloud` クレデンシャル等を含む可能性があるため）

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ chmod +x install.sh
 ./install.sh
 ```
 
-`install.sh` が以下を自動で行います：
+`install.sh` が以下を自動で行います（何度実行しても安全）：
 
-- `dotfiles/.config/*` → `~/.config/*` のシンボリックリンク作成
-- `dotfiles/home/.*` → `~/.*` のシンボリックリンク作成
-- Claude Code の commands/agents のシンボリックリンク作成
+- `dotfiles/.config/*` → `~/.config/*` のシンボリックリンク作成（ディレクトリ単位）
+- `dotfiles/home/.*` → `~/.*` のシンボリックリンク作成（ファイル単位）
+- `dotfiles/.claude/commands/*.md` → `~/.claude/commands/` のシンボリックリンク作成（ファイル単位）
 - 既存ファイルは `~/.dotfiles_backup/<timestamp>/` にバックアップ
 
 ## ディレクトリ構成
@@ -27,6 +27,8 @@ dotfiles/
 │   ├── sheldon/       # sheldon (zsh プラグインマネージャー)
 │   ├── gh-dash/       # gh-dash (GitHub CLI ダッシュボード)
 │   ├── aerospace/     # AeroSpace ウィンドウマネージャー
+│   ├── borders/       # borders (アクティブウィンドウのボーダー表示)
+│   ├── git/           # git 設定（ignore ファイル等）
 │   └── zellij/        # Zellij ターミナルマルチプレクサ
 ├── home/
 │   ├── .zshrc
@@ -42,98 +44,38 @@ dotfiles/
 
 ## ツールのインストール
 
-### シェル
-
 ```bash
+# シェル
 brew install zsh sheldon fzf zoxide atuin mise
-```
 
-### エディタ
-
-```bash
+# エディタ
 brew install neovim
-```
 
-### Git 関連
-
-```bash
+# Git 関連
 brew install git lazygit tig git-delta
-npm install -g git-cz  # lazygit からのコンベンショナルコミット用
-```
+npm install -g git-cz
 
-### CLI ツール
-
-```bash
+# CLI ツール
 brew install eza bat ripgrep fd
 brew install yazi ffmpeg sevenzip jq poppler resvg imagemagick
 brew install lazysql
-```
 
-### GitHub
-
-```bash
+# GitHub
 brew install gh
 gh extension install dlvhdr/gh-dash
-```
 
-### ターミナル
-
-```bash
+# ターミナル
 brew install --cask wezterm@nightly
+brew tap manaflow-ai/cmux && brew install --cask cmux
 
-# cmux - AI コーディングエージェント管理用ターミナル
-brew tap manaflow-ai/cmux
-brew install --cask cmux
-```
-
-### ウィンドウマネージャー
-
-```bash
+# ウィンドウマネージャー
 brew install --cask nikitabobko/tap/aerospace
-brew tap FelixKratz/formulae
-brew install borders  # アクティブウィンドウのボーダー表示
-```
+brew tap FelixKratz/formulae && brew install borders
 
-### ターミナルマルチプレクサ
-
-```bash
+# ターミナルマルチプレクサ
 brew install zellij
 ```
 
-## ツール別メモ
-
-### AeroSpace
-
-キーバインド：
-
-| キー                 | 動作                             |
-| -------------------- | -------------------------------- |
-| `Alt + hjkl`         | フォーカス移動                   |
-| `Alt + Shift + hjkl` | ウィンドウ移動                   |
-| `Alt + 1-9`          | ワークスペース切り替え           |
-| `Alt + S`            | Slack ワークスペース             |
-| `Alt + M`            | Music ワークスペース             |
-| `Alt + B`            | Browser ワークスペース           |
-| `Alt + F`            | フルスクリーン                   |
-| `Alt + Shift + ;`    | サービスモード（設定リロード等） |
-
-アプリのワークスペース自動割り当て：Chrome/Firefox/Safari → B、WezTerm → 1、Slack → S、Spotify → M
-
-### lazygit カスタムコマンド
-
-- `x`: マージ済み（master/staging）&リモート削除済みブランチを一括削除
-- `C`: git-cz でコンベンショナルコミット（要 `npm install -g git-cz`）
-
-### gh-dash カスタムキーバインド
-
-- `g`: リポジトリで lazygit を起動
-- `w`: PR をブラウザで開く
-
-### Claude Code カスタムコマンド
-
-- `/worklog`: 作業ログを Obsidian に記録（要 `OBSIDIAN_VAULT_PATH` 環境変数）
-- `/create-pr`: PR 作成
-
-### ローカル固有設定
+## ローカル固有設定
 
 `~/.zshrc.local` に記述（git 管理外）

--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -4,7 +4,7 @@
   
   [core]
       pager = delta
-      excludesfile = ~/.gitignore_global
+      excludesfile = ~/.config/git/ignore
   
   [interactive]
       diffFilter = delta --color-only

--- a/install.sh
+++ b/install.sh
@@ -78,6 +78,7 @@ log "=== Home dotfiles ==="
 for src_file in "$DOTFILES_DIR/home"/.*; do
     base="$(basename "$src_file")"
     [[ "$base" == "." || "$base" == ".." ]] && continue
+    [[ "$base" == ".config" ]] && continue  # .config は別途 .config/*/ ループで管理
     safe_link "$src_file" "$HOME/$base"
 done
 


### PR DESCRIPTION
## 概要

install.sh の home dotfiles ループで `.config` が誤ってホームにリンクされてしまうバグを修正。
併せて global gitignore を XDG 準拠の `~/.config/git/ignore` に移行し、ドキュメントを整備した。

## 変更内容

- `install.sh`: home ループで `.config` を明示的にスキップする1行を追加
- `.config/git/ignore`: global gitignore を新設（`**/.claude/settings.local.json` を除外）
- `home/.gitconfig`: `excludesfile` を `~/.gitignore_global` → `~/.config/git/ignore` に変更
- `.gitignore`: `home/.config/` を追加（クレデンシャル等を含む可能性があるため）
- `CLAUDE.md`: install.sh の3フェーズの仕組み・重大インシデントの教訓・禁止操作を詳細に記載
- `README.md`: 最新構成に合わせて簡潔化・更新

## テスト方法

- [ ] `./install.sh` を実行して `Already linked:` が表示されること（冪等性の確認）
- [ ] `ls -la ~/.config/ | grep '\->'` で各ツールがディレクトリ単位でリンクされていること
- [ ] `~/.config` 自体がシンボリックリンクになっていないこと