### PR TITLE
mise経由でnodeを管理し、Google Workspace CLIをinstall.shで自動インストール

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,0 +1,5 @@
+[settings]
+idiomatic_version_file_enable_tools = ["ruby"]
+
+[tools]
+node = "lts"

--- a/install.sh
+++ b/install.sh
@@ -105,6 +105,29 @@ for f in "$DOTFILES_DIR/.claude/agents"/*.md; do
 done
 
 # ============================================================
+# npm グローバルパッケージのインストール（mise 経由の node を使用）
+# ============================================================
+log "=== npm global packages ==="
+
+NPM_PACKAGES=(
+    "@googleworkspace/cli"
+)
+
+if command -v mise &>/dev/null; then
+    mise install --quiet
+    for pkg in "${NPM_PACKAGES[@]}"; do
+        if mise exec -- npm list -g "$pkg" &>/dev/null 2>&1; then
+            log "Already installed: $pkg"
+        else
+            log "Installing: $pkg"
+            mise exec -- npm install -g "$pkg"
+        fi
+    done
+else
+    warn "mise not found. Run 'brew bundle install --global' first."
+fi
+
+# ============================================================
 # 完了メッセージ
 # ============================================================
 log ""


### PR DESCRIPTION
## 概要

`node` の管理を Homebrew から `mise` に移行し、`@googleworkspace/cli` を `install.sh` から自動インストールできるようにした。

## 変更内容

- `.config/mise/config.toml` を新規追加（`node = "lts"` を定義、既存 settings も引き継ぎ）
- `install.sh` に Phase 5（npm グローバルパッケージ）を追加
  - `mise install` で node を確保してから `mise exec -- npm install -g` を実行
  - `npm list -g` で既インストール確認し冪等動作を保証
  - `NPM_PACKAGES` 配列で将来のパッケージ追加にも対応

## テスト方法

```bash
# 冪等動作確認（Already installed: が表示されればOK）
./install.sh

# コマンド確認
gws --version

# mise による node 管理確認
mise list
```