### PR TITLE
zeno.zsh を導入して git fuzzy 補完・履歴検索を強化

### DIFF
--- a/.config/sheldon/plugins.toml
+++ b/.config/sheldon/plugins.toml
@@ -47,4 +47,7 @@ github = "MichaelAquilina/zsh-you-should-use"
 [plugins.fzf-tab]
 github = "Aloxaf/fzf-tab"
 
+[plugins.zeno]
+github = "yuki-yano/zeno.zsh"
+
 

--- a/.config/zeno/config.yml
+++ b/.config/zeno/config.yml
@@ -1,0 +1,15 @@
+snippets:
+  # カレントブランチ補完（git push/pull/merge/rebase/checkout -b の後）
+  - name: "current branch"
+    keyword: "B"
+    snippet: "git symbolic-ref --short HEAD"
+    context:
+      lbuffer: '^git\s+(push|pull|merge|rebase|checkout -b)\s+'
+    evaluate: true
+
+  # null リダイレクト（コマンドの後ろにのみ展開）
+  - name: "null redirect"
+    keyword: "null"
+    snippet: ">/dev/null 2>&1"
+    context:
+      lbuffer: '.+\s'

--- a/Brewfile
+++ b/Brewfile
@@ -14,6 +14,7 @@ tap "nikitabobko/tap"      # aerospace
 
 ## シェル・ターミナル環境
 brew "sheldon"  # zsh プラグインマネージャー
+brew "deno"     # zeno.zsh の必須依存
 brew "fzf"      # ファジーファインダー
 brew "zoxide"   # 賢い cd コマンド
 brew "atuin"    # シェル履歴の強化

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ dotfiles/
 │   ├── aerospace/     # AeroSpace ウィンドウマネージャー
 │   ├── borders/       # borders (アクティブウィンドウのボーダー表示)
 │   ├── git/           # git 設定（ignore ファイル等）
-│   └── zellij/        # Zellij ターミナルマルチプレクサ
+│   ├── zellij/        # Zellij ターミナルマルチプレクサ
+│   ├── zeno/          # zeno.zsh (git fuzzy 補完・履歴検索)
+│   └── zsh-abbr/      # zsh-abbr (略語展開)
 ├── home/
 │   ├── .zshrc
 │   ├── .zsh_aliases

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -53,9 +53,20 @@ fi
 # zsh-abbr: ユーザー略語ファイル（sheldon ロード前に設定必須）
 export ABBR_USER_ABBREVIATIONS_FILE="${XDG_CONFIG_HOME}/zsh-abbr/user-abbreviations"
 
+# zeno: ファイルプレビューに bat を使用（sheldon ロード前に設定）
+export ZENO_GIT_CAT="bat"
+
 # excecute
 eval "$(sheldon source)"
 source <(fzf --zsh)
+
+# zeno キーバインド（sheldon + fzf ロード後に設定、^r は fzf --zsh を上書き）
+if [[ -n $ZENO_LOADED ]]; then
+  export ZENO_COMPLETION_FALLBACK="fzf-tab-complete"
+  bindkey '^i'  zeno-completion         # Tab: git fuzzy 補完 → fallback fzf-tab
+  bindkey '^r'  zeno-history-selection  # Ctrl-R: プレビュー付き履歴検索
+  bindkey '^xs' zeno-insert-snippet     # Ctrl-X s: スニペットピッカー
+fi
 
 # For local settings
 if [ -f ~/.zshrc.local ]; then


### PR DESCRIPTION
## 概要

zeno.zsh を dotfiles に統合し、git 操作の fuzzy 補完とプレビュー付き履歴検索を追加する。
既存の zsh-abbr (Space 展開) および fzf-tab (Tab 補完) との競合を避けつつ高機能な機能を採用。

## 変更内容

- `Brewfile`: deno を追加（zeno.zsh の必須依存）
- `.config/sheldon/plugins.toml`: zeno を fzf-tab の後に追加
- `.config/zeno/config.yml`: コンテキスト依存スニペット定義（カレントブランチ・null リダイレクト）
- `home/.zshrc`: キーバインドを追加
  - `^i`: git fuzzy 補完 → fallback fzf-tab
  - `^r`: プレビュー付き履歴検索（fzf --zsh を上書き）
  - `^xs`: スニペットピッカー
- `README.md`: zeno/ と zsh-abbr/ をディレクトリ構成に追記

## テスト方法

1. `brew bundle install --global` で deno をインストール
2. `~/dotfiles/install.sh` で `~/.config/zeno` リンクを作成
3. 新しいターミナルで `echo $ZENO_LOADED` が空でないことを確認
4. `git add <Tab>` で fuzzy 補完が起動することを確認
5. `Ctrl-R` でプレビュー付き履歴検索が起動することを確認
6. `Space` で zsh-abbr の展開が引き続き動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated shell snippet functionality with new key bindings for completions (Ctrl-I), history selection (Ctrl-R), and snippet insertion (Ctrl-X s)
  * Added snippet templates for git branch retrieval and output redirection

* **Chores**
  * Added deno to installed tools
  * Updated documentation with new configuration directories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->