### PR TITLE
feat(lazygit): Claude AIコミットメッセージ自動生成機能の追加と改善

### DIFF
--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -54,10 +54,9 @@ customCommands:
     context: 'files'
     command: >-
       bash -c 'MSG=$(git diff --cached | claude --no-session-persistence --print --model haiku
-      "以下のdiffを元に、Conventional Commits形式のコミットメッセージを日本語で生成してください。
-      1行目: type(scope): 説明（日本語）。type一覧: feat, fix, docs, style, refactor, test, chore。
-      変更の背景・意図・影響範囲が伝わりにくい場合は、1行目の後に空行を挟んで補足メッセージ（本文）を追加してください。
-      単純な変更は1行のみ。メッセージ以外の文言は一切含めないこと。");
+      "以下のdiffを元に、Conventional Commits形式のコミットメッセージを日本語で1行で生成してください。
+      形式: type(scope): 説明（日本語）。type一覧: feat, fix, docs, style, refactor, test, chore。
+      メッセージ以外の文言は一切含めないこと。");
       if [ -z "$MSG" ]; then echo "Error: Claude returned an empty message" >&2; exit 1; fi;
       if echo "$MSG" | grep -qiE "error:|traceback|stack trace|exception"; then echo "Error: Claude returned an error or trace -- $MSG" >&2; exit 1; fi;
       git commit -e -m "$MSG"'

--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -49,6 +49,17 @@ customCommands:
     command: 'git cz'
     description: 'Commit with git-cz'
     output: terminal
+  # Claude AIでコミットメッセージを自動生成
+  - key: '<c-g>'
+    context: 'files'
+    command: >-
+      bash -c 'MSG=$(git diff --cached | claude --no-session-persistence --print --model haiku
+      "Generate ONLY a one-line Git commit message following Conventional Commits format
+      (type(scope): description). Types: feat, fix, docs, style, refactor, test, chore.
+      Based strictly on the diff from stdin. Output ONLY the message, nothing else.")
+      && git commit -e -m "$MSG"'
+    description: 'AI-generated commit message (Claude)'
+    output: terminal
 refresher:
   refreshInterval: 10
   fetchInterval: 60

--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -54,9 +54,10 @@ customCommands:
     context: 'files'
     command: >-
       bash -c 'MSG=$(git diff --cached | claude --no-session-persistence --print --model haiku
-      "以下のdiffを元に、Conventional Commits形式の一行コミットメッセージを日本語で生成してください。
-      形式: type(scope): 説明（日本語）。type一覧: feat, fix, docs, style, refactor, test, chore。
-      メッセージのみ出力し、他の文言は一切含めないこと。")
+      "以下のdiffを元に、Conventional Commits形式のコミットメッセージを日本語で生成してください。
+      1行目: type(scope): 説明（日本語）。type一覧: feat, fix, docs, style, refactor, test, chore。
+      変更の背景・意図・影響範囲が伝わりにくい場合は、1行目の後に空行を挟んで補足メッセージ（本文）を追加してください。
+      単純な変更は1行のみ。メッセージ以外の文言は一切含めないこと。")
       && git commit -e -m "$MSG"'
     description: 'AI-generated commit message (Claude)'
     output: terminal

--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -57,8 +57,10 @@ customCommands:
       "以下のdiffを元に、Conventional Commits形式のコミットメッセージを日本語で生成してください。
       1行目: type(scope): 説明（日本語）。type一覧: feat, fix, docs, style, refactor, test, chore。
       変更の背景・意図・影響範囲が伝わりにくい場合は、1行目の後に空行を挟んで補足メッセージ（本文）を追加してください。
-      単純な変更は1行のみ。メッセージ以外の文言は一切含めないこと。")
-      && git commit -e -m "$MSG"'
+      単純な変更は1行のみ。メッセージ以外の文言は一切含めないこと。");
+      if [ -z "$MSG" ]; then echo "Error: Claude returned an empty message" >&2; exit 1; fi;
+      if echo "$MSG" | grep -qiE "error:|traceback|stack trace|exception"; then echo "Error: Claude returned an error or trace -- $MSG" >&2; exit 1; fi;
+      git commit -e -m "$MSG"'
     description: 'AI-generated commit message (Claude)'
     output: terminal
 refresher:

--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -54,9 +54,9 @@ customCommands:
     context: 'files'
     command: >-
       bash -c 'MSG=$(git diff --cached | claude --no-session-persistence --print --model haiku
-      "Generate ONLY a one-line Git commit message following Conventional Commits format
-      (type(scope): description). Types: feat, fix, docs, style, refactor, test, chore.
-      Based strictly on the diff from stdin. Output ONLY the message, nothing else.")
+      "以下のdiffを元に、Conventional Commits形式の一行コミットメッセージを日本語で生成してください。
+      形式: type(scope): 説明（日本語）。type一覧: feat, fix, docs, style, refactor, test, chore。
+      メッセージのみ出力し、他の文言は一切含めないこと。")
       && git commit -e -m "$MSG"'
     description: 'AI-generated commit message (Claude)'
     output: terminal


### PR DESCRIPTION
## 概要

lazygitにClaude AIを使ったコミットメッセージ自動生成機能を追加した。
`<c-g>` キーでステージ済みdiffをClaudeに渡し、Conventional Commits形式の日本語コミットメッセージを生成する。

## 変更内容

- lazygitカスタムコマンドに `<c-g>` キーバインドを追加
- Claude haiku モデルを使用してコミットメッセージを生成
- Conventional Commits形式 + 日本語でのメッセージ生成
- 複雑な変更には本文（body）も自動生成するプロンプト設計
- プロンプトを日本語化・改善（より適切なコミットメッセージを生成）

## テスト方法

1. lazygitを開く
2. ファイルをステージング
3. `<c-g>` でAI生成コミットメッセージが表示されることを確認
4. エディタが開き、メッセージを編集してコミットできることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Claude AI for automated commit message generation in lazygit. Press `<c-g>` to automatically generate commit messages in Conventional Commits format from staged changes. Generated messages can be reviewed and edited before committing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->