### PR TITLE
feat(abbr): zsh-abbrの設定を整理・拡充

### DIFF
--- a/.config/zsh-abbr/user-abbreviations
+++ b/.config/zsh-abbr/user-abbreviations
@@ -1,10 +1,17 @@
-abbr "d"="docker"
-abbr "dc"="docker-compose"
-abbr "m"="mise"
-abbr "mr"="mise run"
+# editor / directory
 abbr ".."="cd .."
 abbr "..."="cd ../.."
 abbr "vi"="nvim"
+
+# docker
+abbr "d"="docker"
+abbr "dc"="docker-compose"
+
+# mise
+abbr "m"="mise"
+abbr "mr"="mise run"
+
+# git
 abbr "g"="git"
 abbr "ga"="git add"
 abbr "gd"="git diff"
@@ -15,6 +22,8 @@ abbr "gst"="git status"
 abbr "gco"="git checkout"
 abbr "gf"="git fetch"
 abbr "gc"="git commit"
+
+# other tools
 abbr "lg"="lazygit"
 abbr "lq"="lazysql"
 abbr "z"="zellij"

--- a/.config/zsh-abbr/user-abbreviations
+++ b/.config/zsh-abbr/user-abbreviations
@@ -24,7 +24,6 @@ abbr "gf"="git fetch"
 abbr "gc"="git commit"
 abbr "gw"="git worktree"
 
-
 # other tools
 abbr "lg"="lazygit"
 abbr "lq"="lazysql"

--- a/.config/zsh-abbr/user-abbreviations
+++ b/.config/zsh-abbr/user-abbreviations
@@ -15,13 +15,15 @@ abbr "mr"="mise run"
 abbr "g"="git"
 abbr "ga"="git add"
 abbr "gd"="git diff"
-abbr "gs"="git status"
+abbr "gs"="git switch"
 abbr "gp"="git pull"
 abbr "gb"="git branch"
 abbr "gst"="git status"
 abbr "gco"="git checkout"
 abbr "gf"="git fetch"
 abbr "gc"="git commit"
+abbr "gw"="git worktree"
+
 
 # other tools
 abbr "lg"="lazygit"


### PR DESCRIPTION
## 概要

zsh-abbrのユーザー定義略語をカテゴリごとに整理し、不足していたaliasを追加。

## 変更内容

- abbrevをカテゴリ（editor/directory、docker、mise、git、other tools）ごとにコメントで分類
- `gs` を `git status` → `git switch` に変更（`gst` で代替）
- `gw`（git worktree）を新規追加

## テスト方法

- zshを再起動して `abbr list` で登録内容を確認
- `gs<Space>` でgit switchが展開されることを確認
- `gw<Space>` でgit worktreeが展開されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shortcuts for parent (..) and grandparent (...) directory navigation
  * Editor shortcut for Neovim (vi)
  * Git worktree shortcut for managing worktrees

* **Changes**
  * Updated git shortcut: gs now performs branch switching

* **Chore**
  * Abbreviations reorganized into labeled groups for easier discovery and maintenance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->