### PR TITLE
feat: Neovimの隠しファイル検索対応とWeztermタブ名にプロセス情報を表示

### DIFF
--- a/.config/nvim/lua/plugins/snacks.lua
+++ b/.config/nvim/lua/plugins/snacks.lua
@@ -1,0 +1,15 @@
+return {
+  "folke/snacks.nvim",
+  opts = {
+    picker = {
+      sources = {
+        files = {
+          hidden = true,
+        },
+        smart = {
+          hidden = true,
+        },
+      },
+    },
+  },
+}

--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -153,17 +153,38 @@ wezterm.on("format-tab-title", function(tab, tabs, panes, config, hover, max_wid
 		}
 	end
 
+	-- プロセス名のアイコンマッピング
+	local process_icons = {
+		nvim = " ",
+		vim = " ",
+		lazygit = " ",
+		git = " ",
+		ssh = "󰣀 ",
+		node = " ",
+		python3 = " ",
+		python = " ",
+		ruby = " ",
+		cargo = " ",
+		go = " ",
+		docker = " ",
+	}
+
+	-- プロセス名を取得
+	local process = tab.active_pane.foreground_process_name or ""
+	local process_name = process:match("([^/]+)$") or ""
+	local icon = process_icons[process_name] or "󰆍 "
+
 	-- カレントディレクトリ名を取得
 	local cwd = tab.active_pane.current_working_dir
-	local title = tab.active_pane.title
+	local dir = tab.active_pane.title
 
 	if cwd then
 		local cwd_uri = cwd.file_path or tostring(cwd)
-		-- パスからディレクトリ名のみを取得
-		title = cwd_uri:match("([^/]+)/?$") or title
+		dir = cwd_uri:match("([^/]+)/?$") or dir
 	end
 
-	title = "   " .. wezterm.truncate_right(title, max_width - 1) .. "   "
+	local title = icon .. process_name .. "  " .. dir
+	title = "  " .. wezterm.truncate_right(title, max_width - 1) .. "  "
 
 	return {
 		{ Background = { Color = background } },


### PR DESCRIPTION
## 概要

開発体験向上のため、Neovimのファイル検索で隠しファイルを表示するよう設定し、
Weztermのタブにプロセスのアイコンとプロセス名を表示するよう変更した。

## 変更内容

- **Neovim (snacks.lua)**: snacks.nvimのpickerでファイル検索・スマート検索時に隠しファイルを含めるよう設定
- **WezTerm (wezterm.lua)**: タブタイトルにプロセス名のアイコン（nvim, lazygit, git, ssh, node等）とプロセス名を表示

## テスト方法

- Neovim でファイル検索を開き、`.gitignore` や `.zshrc` などの隠しファイルが表示されることを確認
- WezTerm で各プロセス（nvim, lazygit, ssh等）起動時にタブ名が変わることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File picker now includes hidden files in search results for more comprehensive file browsing.
  * Terminal tab titles redesigned to display process icons, process names, and directory information together, offering better visual identification of running applications and their active working locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->