### PR TITLE
feat(nvim): blame.nvimを追加

### DIFF
--- a/.config/nvim/lua/plugins/blame.lua
+++ b/.config/nvim/lua/plugins/blame.lua
@@ -1,0 +1,20 @@
+return {
+  "FabijanZulj/blame.nvim",
+  cmd = { "BlameToggle" },
+  keys = {
+    { "<leader>gb", "<cmd>BlameToggle window<cr>", desc = "Git Blame (window)" },
+    { "<leader>gv", "<cmd>BlameToggle virtual<cr>", desc = "Git Blame (virtual)" },
+  },
+  opts = {
+    date_format = "%Y/%m/%d",
+    virtual_style = "right_align",
+    views = {
+      window = {
+        wintype = "split",
+        width = 45,
+      },
+    },
+    merge_consecutive = false,
+    max_summary_width = 30,
+  },
+}

--- a/.config/nvim/lua/plugins/blame.lua
+++ b/.config/nvim/lua/plugins/blame.lua
@@ -6,8 +6,11 @@ return {
     { "<leader>gv", "<cmd>BlameToggle virtual<cr>", desc = "Git Blame (virtual)" },
   },
   opts = {
-    date_format = "%Y/%m/%d",
+    date_format = "%r",
     virtual_style = "right_align",
+    focus_blame = false,
+    commit_detail_view = "tab",
+    blame_options = { "-w" },
     views = {
       window = {
         wintype = "split",


### PR DESCRIPTION
<leader>gb でウィンドウモード、<leader>gv でvirtualモードのblameを表示。

https://claude.ai/code/session_01WorFUtRw8wNBXVCtYs8H9K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-demand blame view accessible via two keyboard shortcuts for windowed or inline (virtual) display modes.
  * Added configurable display options: date format, alignment, commit detail opens in a tab, condensed summary width, and whitespace-aware blame rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->