### PR TITLE
feat: add Worktrunk git worktree manager integration

### DIFF
--- a/.config/worktrunk/config.toml
+++ b/.config/worktrunk/config.toml
@@ -1,0 +1,12 @@
+# Worktrunk ユーザー設定
+# https://worktrunk.dev/config/
+
+# worktree の作成先パス
+# 専用ディレクトリにまとめる場合（推奨）
+worktree-path = "~/worktrees/{{ repo }}/{{ branch | sanitize }}"
+
+# リポジトリと同階層に作成する場合（デフォルト）
+# worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"
+
+# リポジトリ内部に作成する場合
+# worktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"

--- a/Brewfile
+++ b/Brewfile
@@ -23,9 +23,10 @@ brew "zellij"   # ターミナルマルチプレクサ
 
 ## バージョン管理
 brew "git"
-brew "ghq"      # リポジトリ管理ツール
-brew "lazygit"  # git TUI クライアント
-brew "gh"       # GitHub CLI
+brew "ghq"        # リポジトリ管理ツール
+brew "lazygit"    # git TUI クライアント
+brew "gh"         # GitHub CLI
+brew "worktrunk"  # git worktree マネージャー
 
 ## エディタ・開発ツール
 brew "neovim"

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -86,6 +86,13 @@ if (( $+commands[ghq] && $+commands[fzf] )); then
   bindkey '^G' ghq-fzf
 fi
 
+# worktrunk（git worktree マネージャー）
+# wt switch 実行時に自動でディレクトリ移動するシェル統合
+# 初回インストール後に `wt config shell install` を実行してセットアップ
+if [ -x "$(command -v wt)" ]; then
+  source <(wt shell-init zsh 2>/dev/null) 2>/dev/null || true
+fi
+
 # For local settings
 if [ -f ~/.zshrc.local ]; then
     . ~/.zshrc.local


### PR DESCRIPTION
- Brewfile: worktrunkを追加
- .config/worktrunk/config.toml: worktree path設定（~/worktrees/配下に集約）
- home/.zshrc: シェル統合ブロックを追加（条件付き読み込み）

https://claude.ai/code/session_01D6PETGuewZewjLdfzeYk6P