### PR TITLE
chore(nvim): React/TypeScript設定のインレイヒントと自動実行を無効化

### DIFF
--- a/.config/nvim/lua/config/autocmds.lua
+++ b/.config/nvim/lua/config/autocmds.lua
@@ -70,15 +70,6 @@ vim.api.nvim_create_autocmd("FileType", {
 -- React/TypeScript development autocmds
 local react_group = vim.api.nvim_create_augroup("React", { clear = true })
 
--- Auto-format TypeScript/JavaScript files on save
-vim.api.nvim_create_autocmd("BufWritePre", {
-  group = react_group,
-  pattern = {"*.ts", "*.tsx", "*.js", "*.jsx"},
-  callback = function()
-    vim.lsp.buf.format({ async = false })
-  end,
-})
-
 -- Set proper indentation for JS/TS files
 vim.api.nvim_create_autocmd("FileType", {
   group = react_group,

--- a/.config/nvim/lua/plugins/react.lua
+++ b/.config/nvim/lua/plugins/react.lua
@@ -34,13 +34,13 @@ return {
     opts = {
       settings = {
         tsserver_file_preferences = {
-          includeInlayParameterNameHints = "all",
+          includeInlayParameterNameHints = "none",
           includeInlayParameterNameHintsWhenArgumentMatchesName = false,
-          includeInlayFunctionParameterTypeHints = true,
-          includeInlayVariableTypeHints = true,
-          includeInlayPropertyDeclarationTypeHints = true,
-          includeInlayFunctionLikeReturnTypeHints = true,
-          includeInlayEnumMemberValueHints = true,
+          includeInlayFunctionParameterTypeHints = false,
+          includeInlayVariableTypeHints = false,
+          includeInlayPropertyDeclarationTypeHints = false,
+          includeInlayFunctionLikeReturnTypeHints = false,
+          includeInlayEnumMemberValueHints = false,
         },
       },
     },
@@ -166,24 +166,24 @@ return {
           settings = {
             typescript = {
               inlayHints = {
-                includeInlayParameterNameHints = "all",
+                includeInlayParameterNameHints = "none",
                 includeInlayParameterNameHintsWhenArgumentMatchesName = false,
-                includeInlayFunctionParameterTypeHints = true,
-                includeInlayVariableTypeHints = true,
-                includeInlayPropertyDeclarationTypeHints = true,
-                includeInlayFunctionLikeReturnTypeHints = true,
-                includeInlayEnumMemberValueHints = true,
+                includeInlayFunctionParameterTypeHints = false,
+                includeInlayVariableTypeHints = false,
+                includeInlayPropertyDeclarationTypeHints = false,
+                includeInlayFunctionLikeReturnTypeHints = false,
+                includeInlayEnumMemberValueHints = false,
               },
             },
             javascript = {
               inlayHints = {
-                includeInlayParameterNameHints = "all",
+                includeInlayParameterNameHints = "none",
                 includeInlayParameterNameHintsWhenArgumentMatchesName = false,
-                includeInlayFunctionParameterTypeHints = true,
-                includeInlayVariableTypeHints = true,
-                includeInlayPropertyDeclarationTypeHints = true,
-                includeInlayFunctionLikeReturnTypeHints = true,
-                includeInlayEnumMemberValueHints = true,
+                includeInlayFunctionParameterTypeHints = false,
+                includeInlayVariableTypeHints = false,
+                includeInlayPropertyDeclarationTypeHints = false,
+                includeInlayFunctionLikeReturnTypeHints = false,
+                includeInlayEnumMemberValueHints = false,
               },
             },
           },
@@ -193,6 +193,11 @@ return {
             workingDirectory = { mode = "auto" },
           },
         },
+      },
+      setup = {
+        -- LazyVim の eslint extras はデフォルトで EslintFixAll を保存時に実行するが、
+        -- consistent-type-imports ルールで import が import type に書き換わるためオーバーライドして無効化
+        eslint = function() end,
       },
     },
   },


### PR DESCRIPTION
## 概要

Neovim の React/TypeScript 開発設定において、コーディング中に邪魔になる機能を無効化する。

## 変更内容

- **インレイヒントを全て無効化**: `vtsls`・`ts_ls` のパラメータ名・型ヒント等を `false`/`none` に設定
- **保存時の自動フォーマットを削除**: `autocmds.lua` から `BufWritePre` による `vim.lsp.buf.format()` の自動実行を削除
- **ESLint 自動実行を無効化**: LazyVim デフォルトの `EslintFixAll` 保存時自動実行をオーバーライドして無効化（`consistent-type-imports` ルールによる `import` → `import type` の意図しない書き換えを防ぐ）

## テスト方法

- Neovim で TypeScript/React ファイルを開き、インレイヒントが表示されないことを確認
- 保存時に自動フォーマットや ESLint 自動修正が実行されないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled code formatting on save for React and TypeScript/JavaScript files.
  * Disabled TypeScript inlay hints.
  * Disabled ESLint auto-fix on save.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->